### PR TITLE
Change mount path for schema files

### DIFF
--- a/charts/worker/templates/_helpers.tpl
+++ b/charts/worker/templates/_helpers.tpl
@@ -76,7 +76,7 @@ Create the name of the worker user file config maps and volumes to use
 {{- end }}
 
 {{- define "worker.baseUserFilesMountPath" -}}
-/usr/local/lib/skyramp/idl
+/etc/skyramp/idl
 {{- end }}
 
 {{- define "worker.userThriftFilesMountPath" -}}


### PR DESCRIPTION
This is used to remove the "double deploy" requirement.