### PR TITLE
fix clusterrole/clusterrole binding to support multi worker deployment

### DIFF
--- a/charts/worker/templates/_helpers.tpl
+++ b/charts/worker/templates/_helpers.tpl
@@ -52,6 +52,15 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the cluster role to use
+*/}}
+{{- define "worker.clusterRoleName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- printf "%s-%s" (include "worker.fullname" .) .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
 Boot config
 */}}
 {{- define "worker.bootConfig" -}}

--- a/charts/worker/templates/skyramp-worker-clusterrole.yaml
+++ b/charts/worker/templates/skyramp-worker-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "worker.fullname" . }}
+  name: {{ include "worker.clusterRoleName" . }}
   labels:
     {{- include "worker.labels" . | nindent 4 }}
 rules:

--- a/charts/worker/templates/skyramp-worker-clusterrolebinding.yaml
+++ b/charts/worker/templates/skyramp-worker-clusterrolebinding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "worker.fullname" . }}
+  name: {{ include "worker.clusterRoleName" . }}
   labels:
     {{- include "worker.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "worker.fullname" . }}
+  name: {{ include "worker.clusterRoleName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "worker.serviceAccountName" . }}


### PR DESCRIPTION
A ClusterRole in Kubernetes can only have a single owner, which is specified by the meta.helm.sh/release-namespace annotation in the case of Helm releases. To support having multiple workers deployed across different namespaces in the same cluster, we suffix the name of the ClusterRole/ClusterRoleBinding to include the namespace. Tested this resolves the ownership regression issue we saw and can now successfully deploy multiple workers. 