### PR TITLE
Remove default RBAC permissions for worker

### DIFF
--- a/charts/worker/templates/_helpers.tpl
+++ b/charts/worker/templates/_helpers.tpl
@@ -44,18 +44,14 @@ app.kubernetes.io/part-of: skyramp
 Create the name of the service account to use
 */}}
 {{- define "worker.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "worker.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{ include "worker.fullname" . }}
 {{- end }}
 
 {{/*
 Create the name of the cluster role to use
 */}}
 {{- define "worker.clusterRoleName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.rbac }}
 {{- printf "%s-%s" (include "worker.fullname" .) .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/charts/worker/templates/skyramp-worker-clusterrole.yaml
+++ b/charts/worker/templates/skyramp-worker-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.rbac -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/worker/templates/skyramp-worker-clusterrolebinding.yaml
+++ b/charts/worker/templates/skyramp-worker-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.rbac -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/worker/templates/skyramp-worker-role.yaml
+++ b/charts/worker/templates/skyramp-worker-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.rbac -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/worker/templates/skyramp-worker-rolebinding.yaml
+++ b/charts/worker/templates/skyramp-worker-rolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.serviceAccount.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -7,9 +6,13 @@ metadata:
     {{- include "worker.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if .Values.rbac }}
   kind: Role
   name: {{ include "worker.fullname" . }}
+{{- else }}
+  kind: ClusterRole
+  name: edit 
+{{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "worker.serviceAccountName" . }}
-{{- end }}

--- a/charts/worker/templates/skyramp-worker-serviceaccount.yaml
+++ b/charts/worker/templates/skyramp-worker-serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,4 +8,3 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -11,14 +11,13 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 
+# Whether higher level permissions should be requested for the Skyramp worker.
+# This is required for various functionality, such as detailed k8s metrics fetching.
+rbac: false
+
 serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
   # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
 
 podAnnotations: {}
 


### PR DESCRIPTION
- Removes some `serviceAccount` values that aren't used
- Adds an `rbac` boolean value, which is by default `false`, which determines whether elevated permissions are requested for the worker
- If `rbac` is `false`, uses a default `edit` `ClusterRole` for the worker's `RoleBinding`