### PR TITLE
SKYR-2273: add opentsdb chart

### DIFF
--- a/charts/opentsdb/Chart.yaml
+++ b/charts/opentsdb/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: opentsdb
+description: Skyramp opentsdb chart
+type: application
+version: 0.1.0
+appVersion: "1.1.0"

--- a/charts/opentsdb/README.md
+++ b/charts/opentsdb/README.md
@@ -1,0 +1,20 @@
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts.  Please refer to
+Helm's [documentation](https://helm.sh/docs) to get started.
+
+Once Helm has been set up correctly, add the repo as follows:
+
+    helm repo add skyramp https://letsramp.github.io/helm/
+
+If you had already added this repo earlier, run `helm repo update` to retrieve
+the latest versions of the packages.  You can then run `helm search repo
+skyramp` to see the charts.
+
+To install the opentsdb chart:
+
+    helm install my-opentsdb skyramp/opentsdb -n skyramp
+
+To uninstall the chart:
+
+    helm delete my-wopentsdb

--- a/charts/opentsdb/justfile
+++ b/charts/opentsdb/justfile
@@ -1,0 +1,8 @@
+namespace := "skyramp"
+
+create-namespace:
+    kubectl create namespace {{namespace}} || echo "Namespace {{namespace}} already exists"
+
+
+install-opentsdb:
+    helm install -n {{ namespace }} opentsdb .

--- a/charts/opentsdb/templates/_helpers.tpl
+++ b/charts/opentsdb/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "opentsdb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "opentsdb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "opentsdb.labels" -}}
+helm.sh/chart: {{ include "opentsdb.chart" . }}
+{{ include "opentsdb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "opentsdb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "opentsdb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "opentsdb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }} 

--- a/charts/opentsdb/templates/deployment.yaml
+++ b/charts/opentsdb/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opentsdb.fullname" . }}
+  labels:
+    {{- include "opentsdb.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "opentsdb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "opentsdb.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 4242
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data/hbase
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/charts/opentsdb/templates/service.yaml
+++ b/charts/opentsdb/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opentsdb.fullname" . }}
+  labels:
+    {{- include "opentsdb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "opentsdb.selectorLabels" . | nindent 4 }} 

--- a/charts/opentsdb/values.yaml
+++ b/charts/opentsdb/values.yaml
@@ -1,0 +1,22 @@
+# Default values for OpenTSDB
+replicaCount: 1
+
+image:
+  repository: petergrace/opentsdb-docker
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 4242
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+# Additional environment variables
+env: []

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -67,6 +67,6 @@ ManagementPlaneConfig:
     database: "dashboarddb"
     testResultCollection: "testresults"
     mockCollection: "servicemocks"
-  prometheusConfig:
+  metricsConfig:
     enabled: true
-    pushGatewayUrl: http://prom-prometheus-pushgateway.skyramp:9091
+    pushGatewayUrl: http://opentsdb.skyramp:4242


### PR DESCRIPTION
Add opentsdb as helm chart and update worker to use opentsdb as default server for metrics