### PR TITLE
Update Helm Skyramp Worker to v1.2.23

### DIFF
--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.46
+version: 0.2.47
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.22"
+appVersion: "v1.2.23"


### PR DESCRIPTION
Update Helm Skyramp Worker to v1.2.23

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps Helm worker chart version to 0.2.47 and application version to v1.2.23.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99eaddab944973950345ac62a79b2888f9bd98ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->